### PR TITLE
error Progresbar example

### DIFF
--- a/qb-core/client-function-reference.md
+++ b/qb-core/client-function-reference.md
@@ -188,7 +188,6 @@ QBCore.Functions.Progressbar('Changeme', 'What the player sees', 1500, false, tr
     end, function()
         -- This code runs if the progress bar gets cancelled
     end)
-end)
 ```
 
 ### QBCore.Functions.GetVehicles


### PR DESCRIPTION
there is an error in then function QBCore.Functions.Progressbar() in the example there is an end)