### PR TITLE
Removed extra end that isn't needed

### DIFF
--- a/qb-core/client-function-reference.md
+++ b/qb-core/client-function-reference.md
@@ -191,7 +191,6 @@ QBCore.Functions.Progressbar('Changeme', 'What the player sees', 1500, false, tr
         -- This code runs if the progress bar completes successfully
     end, function()
         -- This code runs if the progress bar gets cancelled
-    end)
 end)
 ```
 


### PR DESCRIPTION
Removed extra end that isn't needed (Original code has error in VSCode and error in-game) removing this end gets rid of the error and allows the code to run