### PR TITLE
Add documentation for new QBCore client events

### DIFF
--- a/qb-core/client-event-reference.md
+++ b/qb-core/client-event-reference.md
@@ -115,6 +115,27 @@ RegisterNetEvent('QBCore:Player:SetPlayerData', function(val)
 end)
 ```
 
+### QBCore:Client:VehicleInfo
+
+{% hint style="success" %}
+This event can be used as an event handler to trigger code because it indicates that the player has interacted with a vehicle!
+{% endhint %}
+
+Data fields:
+
+|  Field  |  Type  |              Description              |
+| :-----: | :----: | :-----------------------------------: |
+| vehicle | number |          Vehicle Network ID           |
+|  seat   | number | Seat number (-1, 0, 1, 2, 3, 4, 5, 6) |
+|  name   | string |          Model Display Name           |
+|  event  | string |        Entering, Entered, Left        |
+
+```lua
+RegisterNetEvent('QBCore:Client:VehicleInfo', function(data)
+    print(QBCore.Debug(data))
+end)
+```
+
 ### QBCore:Notify
 
 | Arguments |       Type      | Required |    Default    |
@@ -256,6 +277,152 @@ RegisterCommand('3dtext', function(source, args)
     local message = table.concat(args, ' ')
     TriggerClientEvent('QBCore:Command:ShowMe3D', source, message)
 end)
+```
+
+### QBCore:Client:OnSharedUpdate
+
+{% hint style="info" %}
+Server example
+{% endhint %}
+
+{% hint style="important" %}
+This only updates shared data for the client, it does not update the server. Also it does not persist through server restarts. To make persistent changes you must update the shared files.
+{% endhint %}
+
+Arguments:
+
+1. tableName: The Shared field it should be updated
+2. key: Key of the field to update
+3. value: New value of the field to update
+
+```lua
+    RegisterCommand('addjob', function()
+        TriggerClientEvent('QBCore:Client:OnSharedUpdate', -1, 'Jobs', 'sheriff'. {
+            label = 'Sheriff\'s',
+            type = 'leo',
+            defaultDuty = true,
+            offDutyPay = false,
+            grades = {
+                ['0'] = { name = 'Recruit', payment = 50 },
+                ['1'] = { name = 'Officer', payment = 75 },
+                ['2'] = { name = 'Sergeant', payment = 100 },
+                ['3'] = { name = 'Lieutenant', payment = 125 },
+                ['4'] = { name = 'Sheriff', isboss = true, payment = 150 },
+            },
+        })
+    end)
+```
+
+### QBCore:Client:OnSharedUpdateMultiple
+
+{% hint style="info" %}
+Server example
+{% endhint %}
+
+{% hint style="important" %}
+This only updates shared data for the client, it does not update the server. Also it does not persist through server restarts. To make persistent changes you must update the shared files.
+{% endhint %}
+
+Arguments:
+
+1. tableName: The Shared field it should be updated
+2. values: The key-value pairs to update
+
+```lua
+    RegisterCommand('addjob', function()
+        TriggerClientEvent('QBCore:Client:OnSharedUpdate', -1, 'Jobs', {
+            sheriff = {
+                label = 'Sheriff\'s',
+                type = 'leo',
+                defaultDuty = true,
+                offDutyPay = false,
+                grades = {
+                    ['0'] = { name = 'Recruit', payment = 50 },
+                    ['1'] = { name = 'Officer', payment = 75 },
+                    ['2'] = { name = 'Sergeant', payment = 100 },
+                    ['3'] = { name = 'Lieutenant', payment = 125 },
+                    ['4'] = { name = 'Sheriff', isboss = true, payment = 150 },
+                },
+            },
+            lspd = {
+                label = 'LSPD',
+                type = 'leo',
+                defaultDuty = true,
+                offDutyPay = false,
+                grades = {
+                    ['0'] = { name = 'Recruit', payment = 50 },
+                    ['1'] = { name = 'Officer', payment = 75 },
+                    ['2'] = { name = 'Sergeant', payment = 100 },
+                    ['3'] = { name = 'Lieutenant', payment = 125 },
+                    ['4'] = { name = 'Chief', isboss = true, payment = 150 },
+                },
+            }
+        })
+    end)
+```
+
+### QBCore:Client:SharedUpdate
+
+{% hint style="info" %}
+Server example
+{% endhint %}
+
+{% hint style="important" %}
+This only updates shared data for the client, it does not update the server. Also it does not persist through server restarts. To make persistent changes you must update the shared files.
+{% endhint %}
+
+Arguments:
+
+1. table: All shared data
+
+```lua
+    RegisterCommand('setshared', function()
+        local newShared = {
+            Jobs = {
+                sheriff = {
+                    label = 'Sheriff\'s',
+                    type = 'leo',
+                    defaultDuty = true,
+                    offDutyPay = false,
+                    grades = {
+                        ['0'] = { name = 'Recruit', payment = 50 },
+                        ['1'] = { name = 'Officer', payment = 75 },
+                        ['2'] = { name = 'Sergeant', payment = 100 },
+                        ['3'] = { name = 'Lieutenant', payment = 125 },
+                        ['4'] = { name = 'Sheriff', isboss = true, payment = 150 },
+                    },
+                },
+                lspd = {
+                    label = 'LSPD',
+                    type = 'leo',
+                    defaultDuty = true,
+                    offDutyPay = false,
+                    grades = {
+                        ['0'] = { name = 'Recruit', payment = 50 },
+                        ['1'] = { name = 'Officer', payment = 75 },
+                        ['2'] = { name = 'Sergeant', payment = 100 },
+                        ['3'] = { name = 'Lieutenant', payment = 125 },
+                        ['4'] = { name = 'Chief', isboss = true, payment = 150 },
+                    },
+                }
+            },
+            Items = {
+                sandwich = {
+                    name = 'sandwich',
+                    label = 'Sandwich',
+                    weight = 200,
+                    type = 'item',
+                    image = 'sandwich.png',
+                    unique = false,
+                    useable = true,
+                    shouldClose = true,
+                    combinable = nil,
+                    description = 'A tasty sandwich',
+                }
+            }
+        }
+        TriggerClientEvent('QBCore:Client:SharedUpdate', -1, newShared)
+    end)
 ```
 
 ### QBCore:Client:UpdateObject

--- a/qb-core/client-event-reference.md
+++ b/qb-core/client-event-reference.md
@@ -6,7 +6,7 @@ description: Learn about and how to use common core client events!
 
 ### QBCore:Client:OnPlayerLoaded
 
-* Handles the player loading in after character selection
+-   Handles the player loading in after character selection
 
 {% hint style="success" %}
 This event can be used as an event handler to trigger code because it signifies the player has successfully loaded into the server!
@@ -20,7 +20,7 @@ end)
 
 ### QBCore:Client:OnPlayerUnload
 
-* Handles the player login out to character selection
+-   Handles the player login out to character selection
 
 {% hint style="success" %}
 This event can be used as an event handler to trigger code because it signifies the player has successfully unloaded or logged out of the server!
@@ -48,7 +48,7 @@ end)
 
 |   Arguments   |  Type  | Required | Default |
 | :-----------: | :----: | :------: | :-----: |
-| vehicle model | string |    yes   |   none  |
+| vehicle model | string |   yes    |  none   |
 
 {% hint style="info" %}
 Client example
@@ -80,7 +80,7 @@ end)
 
 | Arguments | Type | Required | Default |
 | :-------: | :--: | :------: | :-----: |
-|    none   | none |    no    |   none  |
+|   none    | none |    no    |  none   |
 
 {% hint style="info" %}
 Client example
@@ -138,11 +138,11 @@ end)
 
 ### QBCore:Notify
 
-| Arguments |       Type      | Required |    Default    |
+| Arguments |      Type       | Required |    Default    |
 | :-------: | :-------------: | :------: | :-----------: |
-|  message  | string \| table |    yes   | 'Placeholder' |
-|    type   |      string     |    yes   |   'primary'   |
-|   length  |      number     |    yes   |      5000     |
+|  message  | string \| table |   yes    | 'Placeholder' |
+|   type    |     string      |   yes    |   'primary'   |
+|  length   |     number      |   yes    |     5000      |
 
 {% hint style="info" %}
 Client example
@@ -212,7 +212,7 @@ end)
 
 | Arguments |  Type  | Required | Default |
 | :-------: | :----: | :------: | :-----: |
-| item name | string |    yes   |   none  |
+| item name | string |   yes    |  none   |
 
 {% hint style="info" %}
 Client example (must have the item in your inventory)
@@ -250,8 +250,8 @@ end)
 
 | Arguments |  Type  | Required | Default |
 | :-------: | :----: | :------: | :-----: |
-| player id | number |    yes   |   none  |
-|  message  | string |    yes   |   none  |
+| player id | number |   yes    |  none   |
+|  message  | string |   yes    |  none   |
 
 {% hint style="info" %}
 Client example
@@ -291,13 +291,13 @@ This only updates shared data for the client, it does not update the server. Als
 
 Arguments:
 
-1. tableName: The Shared field it should be updated
+1. tableName: The Shared field that should be updated
 2. key: Key of the field to update
 3. value: New value of the field to update
 
 ```lua
     RegisterCommand('addjob', function()
-        TriggerClientEvent('QBCore:Client:OnSharedUpdate', -1, 'Jobs', 'sheriff'. {
+        TriggerClientEvent('QBCore:Client:OnSharedUpdate', -1, 'Jobs', 'sheriff', {
             label = 'Sheriff\'s',
             type = 'leo',
             defaultDuty = true,
@@ -330,7 +330,7 @@ Arguments:
 
 ```lua
     RegisterCommand('addjob', function()
-        TriggerClientEvent('QBCore:Client:OnSharedUpdate', -1, 'Jobs', {
+        TriggerClientEvent('QBCore:Client:OnSharedUpdateMultiple', -1, 'Jobs', {
             sheriff = {
                 label = 'Sheriff\'s',
                 type = 'leo',


### PR DESCRIPTION
Documents the QBCore:Client:VehicleInfo, QBCore:Client:OnSharedUpdate, QBCore:Client:OnSharedUpdateMultiple, and QBCore:Client:SharedUpdate events. Includes usage examples, argument details, and notes on client-side data updates for each event.